### PR TITLE
Migrate to μhtml

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,6 @@ module.exports = {
     },
   },
   rules: {
-    // We should allow hyperHTML.bind at index.js
-    'no-unused-expressions': ['error', { allowTaggedTemplates: true }],
-
     // We use bitwise operators in this project
     'no-bitwise': ['error', { allow: ['&', '|', '>>', '<<'] }],
 

--- a/dependencies/index.js
+++ b/dependencies/index.js
@@ -9,5 +9,6 @@ export default {
     window,
     setTimeout,
     random: Math.random,
+    DocumentFragment: () => new DocumentFragment(),
   },
 };

--- a/dependencies/index.js
+++ b/dependencies/index.js
@@ -1,7 +1,9 @@
 import { bind, wire } from 'hyperhtml/esm';
+import { render, html } from 'uhtml';
 
 export default {
   hyperhtml: { bind, wire },
+  uhtml: { render, html },
   globals: {
     now: Date.now,
     window,

--- a/dependencies/index.js
+++ b/dependencies/index.js
@@ -1,8 +1,6 @@
-import { bind, wire } from 'hyperhtml/esm';
 import { render, html } from 'uhtml';
 
 export default {
-  hyperhtml: { bind, wire },
   uhtml: { render, html },
   globals: {
     now: Date.now,

--- a/dependencies/test.js
+++ b/dependencies/test.js
@@ -18,5 +18,6 @@ export default {
       addEventListener: () => {},
     }),
     random: shadow(Math.random),
+    DocumentFragment: shadow(() => {}),
   },
 };

--- a/dependencies/test.js
+++ b/dependencies/test.js
@@ -5,6 +5,10 @@ export default {
     bind: shadow(() => {}),
     wire: shadow(() => {}),
   },
+  uhtml: {
+    render: shadow(() => {}),
+    html: shadow(() => {}),
+  },
   globals: {
     now: shadow(Date.now),
     setTimeout: shadow(setTimeout),

--- a/dependencies/test.js
+++ b/dependencies/test.js
@@ -1,10 +1,6 @@
 import { shadow } from '@/lib/shadow';
 
 export default {
-  hyperhtml: {
-    bind: shadow(() => {}),
-    wire: shadow(() => {}),
-  },
   uhtml: {
     render: shadow(() => {}),
     html: shadow(() => {}),

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ import titleView from './view/title/title';
 import indexPhase, { initialState } from './phase/index';
 import titlePhase from './phase/title/title';
 
-const { bind } = dependencies.hyperhtml;
+const { render, html } = dependencies.uhtml;
 
-bind(document.getElementById('root'))`${
+render(document.getElementById('root'), html`${
   [
     caseNumbersView,
     caseTapesView,
@@ -29,6 +29,6 @@ bind(document.getElementById('root'))`${
     totalResultView,
     titleView,
   ].map((view) => view.render())
-}`;
+}`);
 
 runPhase(indexPhase(titlePhase(0), initialState(randomTape(), randomTape())), idealTimeout);

--- a/lib/view.js
+++ b/lib/view.js
@@ -18,6 +18,6 @@ export const view = (defaultProps, renderFunction) => {
 
 const snakeCase = (s) => s.replace(/[A-Z]/g, (upperChar) => (`-${upperChar.toLowerCase()}`));
 
-export const styleToString = (styleObject) => (
-  Object.entries(styleObject).reduce((acc, [key, value]) => `${acc}${snakeCase(key)}:${value};`)
+export const toCssText = (styleObject) => (
+  Object.entries(styleObject).reduce((acc, [key, value]) => `${acc}${snakeCase(key)}:${value};`, '')
 );

--- a/lib/view.js
+++ b/lib/view.js
@@ -1,9 +1,11 @@
 import dependencies from 'dependencies';
 
-const { wire } = dependencies.hyperhtml;
+const { render, html } = dependencies.uhtml;
+const { DocumentFragment } = dependencies.globals;
 
-export default (defaultProps, renderFunction) => {
-  const renderImpl = renderFunction(wire({}));
+export const view = (defaultProps, renderFunction) => {
+  const fragment = DocumentFragment();
+  const renderImpl = (props) => render(fragment, renderFunction(html)(props));
   let props = defaultProps;
   return {
     render: () => renderImpl(props),

--- a/lib/view.js
+++ b/lib/view.js
@@ -15,3 +15,9 @@ export const view = (defaultProps, renderFunction) => {
     },
   };
 };
+
+const snakeCase = (s) => s.replace(/[A-Z]/g, (upperChar) => (`-${upperChar.toLowerCase()}`));
+
+export const styleToString = (styleObject) => (
+  Object.entries(styleObject).reduce((acc, [key, value]) => `${acc}${snakeCase(key)}:${value};`)
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2757,10 +2757,49 @@
       "resolved": "https://registry.npmjs.org/uarray/-/uarray-1.0.0.tgz",
       "integrity": "sha512-LHmiAd5QuAv7pU2vbh+Zq9YOnqVK0H764p2Ozinpfy9ka58OID4IsGLiXsitqH7n0NAIDxvax1A/kDXpii/Ckg=="
     },
+    "udomdiff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/udomdiff/-/udomdiff-1.1.0.tgz",
+      "integrity": "sha512-aqjTs5x/wsShZBkVagdafJkP8S3UMGhkHKszsu1cszjjZ7iOp86+Qb3QOFYh01oWjPMy5ZTuxD6hw5uTKxd+VA=="
+    },
+    "uhandlers": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/uhandlers/-/uhandlers-0.3.5.tgz",
+      "integrity": "sha512-v5j3eTz8DxEGz89EgTvkCmRt+dZqmUSLB8fCzBQ1v3irsVB8WZr1gfbxm/ZpvcDv5m1r0NlXteg7fx7Rg/YP5w==",
+      "requires": {
+        "uarray": "^1.0.0"
+      }
+    },
+    "uhtml": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uhtml/-/uhtml-2.0.0.tgz",
+      "integrity": "sha512-Pis4AF6PO9FPuGDVytLgEcpaLFcFRSLVEV/ldCXdDoKBFYFupFtiag277HbT3jpUT6uPB48GXOA+ZISZaTFhHA==",
+      "requires": {
+        "@ungap/create-content": "^0.2.0",
+        "uarray": "^1.0.0",
+        "udomdiff": "^1.1.0",
+        "uhandlers": "^0.3.5",
+        "umap": "^1.0.2",
+        "uparser": "^0.2.1",
+        "uwire": "^1.0.1"
+      },
+      "dependencies": {
+        "@ungap/create-content": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@ungap/create-content/-/create-content-0.2.0.tgz",
+          "integrity": "sha512-CvmX0Mr5PfFARDBbSef0B+SAqSeMKaHOG/twJi9nbPtp/MiNPgyBLqZndiyO3RXQ0RXy6TqwarvB6KWzTmc4MQ=="
+        }
+      }
+    },
     "umap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/umap/-/umap-1.0.2.tgz",
       "integrity": "sha512-bW127HgG4H4VAD6qlqO5vCC+7bnlYvZ6A6BdwyGblkWvlEG7VYpj1bcpf3iJpvyKmkPZWDIeZDmoULz67ec7NA=="
+    },
+    "uparser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/uparser/-/uparser-0.2.1.tgz",
+      "integrity": "sha512-hTwK8e+bAaER8gJBOysoFGjRPsX/xOthSPR/ieI9EgTf1rts9ey25tbDXIU0rDr/cGcLsvkCo1n8J/eccfAvvw=="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -2769,6 +2808,14 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "uwire": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uwire/-/uwire-1.0.1.tgz",
+      "integrity": "sha512-LOFKTfjqUu+DXbOAxj2Jruy6KY2bDx+HT6JrTOHQFD3a7rPew0ZTkzxef2/1hRBn+YM5wRdwDMAqwqpxoEVWtg==",
+      "requires": {
+        "uarray": "^1.0.0"
       }
     },
     "v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,62 +79,6 @@
         "@types/node": "*"
       }
     },
-    "@ungap/create-content": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@ungap/create-content/-/create-content-0.1.4.tgz",
-      "integrity": "sha512-YM6YQkF5wUxJlw5yDzEAzJfPK/kXR/GxIARx4NNJCInfx/nirHmy3ujPjfi7CaXjcVCwyfpv3vKQm6h762lbRA=="
-    },
-    "@ungap/custom-event": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/custom-event/-/custom-event-0.2.0.tgz",
-      "integrity": "sha512-jovJx+4IaAL8JAzepJXDBVlS9t9mR3vKbbjcHwHCF+sN0KKCYQ2pNVAlQYiRrPqeNBl5VXU7uUDOKBg9ODB+0Q=="
-    },
-    "@ungap/essential-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/essential-map/-/essential-map-0.2.0.tgz",
-      "integrity": "sha512-PM7rUPhH2IAeDZXGjMi1KwNVW/4b/wxfzlPkZSXacHA5A98n+PdCou+HD2EaeXlO8pY5Tp81Ysg+J2xB7J/mjw=="
-    },
-    "@ungap/essential-weakset": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/essential-weakset/-/essential-weakset-0.1.2.tgz",
-      "integrity": "sha512-Z7CBb/xr5V6wvdkdxKkDN0iUDz+EFfXW+O715VoWaDm1UiP+drx4U6S6aFhqYpKt0vTfbWHqrjdWj44B8q4A3A=="
-    },
-    "@ungap/import-node": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ungap/import-node/-/import-node-0.1.0.tgz",
-      "integrity": "sha512-FymNeJTWYNrZcnj7HFJwdaAZWrD1bUv8Na60RGIA142qtaRcOZs0KHGh+QSy7u7GNpW6wGnw9EdCQx4IYPE8cg=="
-    },
-    "@ungap/is-array": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@ungap/is-array/-/is-array-0.1.1.tgz",
-      "integrity": "sha512-867tkp7LhJsOS3iULhhCluRV69bwyRQgBEwZSkm6VnZs8LFVD6VWFugiWc7Zgxwx4Psbrrou15u57n8YNIbKAQ=="
-    },
-    "@ungap/template-literal": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@ungap/template-literal/-/template-literal-0.4.1.tgz",
-      "integrity": "sha512-+hoSovATXOiz+KaKP8qHSl1/4Pgvne1/1CjD17GeQv8AAIMU2JFTPidqYFowrpAFPvuzuSn3fUVQygePVNp/WQ==",
-      "requires": {
-        "@ungap/weakmap": "^0.1.4"
-      }
-    },
-    "@ungap/template-tag-arguments": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/template-tag-arguments/-/template-tag-arguments-0.3.1.tgz",
-      "integrity": "sha512-UGZGVfvEu1VenIPXQl/0IF/uTBoryMf0WZXWAgMC/HQECiUm0Cmy3DYB1sS3ybQf9XuXrYTUIECD3xTzQ0A9og==",
-      "requires": {
-        "@ungap/template-literal": "^0.4.1"
-      }
-    },
-    "@ungap/trim": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@ungap/trim/-/trim-0.1.1.tgz",
-      "integrity": "sha512-f2jiPMFD8qmoNV5kxZ6RwSwmnloxtGUcG3W5Fbe9rC3vwXlPxWT0g5J0mN3+rM9C/u1p24gIVTSxNBPOtyu7Sw=="
-    },
-    "@ungap/weakmap": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@ungap/weakmap/-/weakmap-0.1.4.tgz",
-      "integrity": "sha512-TO4TTwlQXdjHKoWgKxsMqApnOV8JruaNilqOg0I04MTYb5+fj9taIVijS4ILwWg0ytQY5DwTKzPWj+0G+7bsXw=="
-    },
     "acorn": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -560,11 +504,6 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
-    "disconnected": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/disconnected/-/disconnected-0.2.1.tgz",
-      "integrity": "sha512-483TUpj4dA7Ye42xrErztbw3PKpkboPf1aB9mG4+S+RGGxFVv72hQBbS8MqN8LZLWHzfcmk2tMTRR5CoyxNglg=="
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -572,41 +511,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "domconstants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/domconstants/-/domconstants-0.1.1.tgz",
-      "integrity": "sha512-Pk4K6tLOzSh0cZDuh7TQivZtYLC6Z8dNissoDyy2tQoVNg8ewScxG3AVJO76kLcTta/u7bgEO6xbIR97MiInfA=="
-    },
-    "domdiff": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/domdiff/-/domdiff-2.2.2.tgz",
-      "integrity": "sha512-Pv7aH5JfjNIkLRKkah+T3Kd41Gy+7GU+5dmPsOZZXsCJ34QR1i7CCiWraUn1c/a40htShxAQ8mHJR2OqPd12+Q==",
-      "requires": {
-        "uarray": "^1.0.0"
-      }
-    },
-    "domsanitizer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/domsanitizer/-/domsanitizer-0.2.2.tgz",
-      "integrity": "sha512-2nqCaLWi+tpT7oOa862BVrG7bHzYlWFZ5ltmvt4LXECxe5FnwF/zKGs/gWanZWGmv1pwdUTkO9TamoZMqI0Pmg==",
-      "requires": {
-        "domconstants": "^0.1.1"
-      }
-    },
-    "domtagger": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/domtagger/-/domtagger-0.6.2.tgz",
-      "integrity": "sha512-2z7re+gh8Gv6AUuoAhWsF8JXJtNaQCyplYt4p9piSZQ/ivDJ+goDXmKGqKWbc4BniZTD3X/kxm8DEjS12MhPAw==",
-      "requires": {
-        "@ungap/create-content": "^0.1.4",
-        "@ungap/import-node": "^0.1.0",
-        "@ungap/trim": "^0.1.1",
-        "@ungap/weakmap": "^0.1.4",
-        "domconstants": "^0.1.1",
-        "domsanitizer": "^0.2.2",
-        "umap": "^1.0.2"
       }
     },
     "dotignore": {
@@ -1221,35 +1125,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
-    },
-    "hyperhtml": {
-      "version": "2.32.2",
-      "resolved": "https://registry.npmjs.org/hyperhtml/-/hyperhtml-2.32.2.tgz",
-      "integrity": "sha512-F4r0MtZn2aQtUUafe009kQPfNoW7cZvK/r3XrDjW5WiybWMCWGRv1WqCYdbMxChLhgNcdklQh3aMl0gbERlOnQ==",
-      "requires": {
-        "@ungap/create-content": "^0.1.4",
-        "@ungap/custom-event": "^0.2.0",
-        "@ungap/essential-map": "^0.2.0",
-        "@ungap/essential-weakset": "^0.1.2",
-        "@ungap/is-array": "^0.1.1",
-        "@ungap/template-tag-arguments": "^0.3.1",
-        "@ungap/weakmap": "^0.1.4",
-        "disconnected": "^0.2.1",
-        "domdiff": "^2.2.2",
-        "domtagger": "^0.6.2",
-        "hyperhtml-style": "^0.1.2",
-        "hyperhtml-wire": "^2.1.0"
-      }
-    },
-    "hyperhtml-style": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/hyperhtml-style/-/hyperhtml-style-0.1.2.tgz",
-      "integrity": "sha512-ZDRYNClEaqUS0a8RAED0nQRqWmZk7ctdyij3Iw/PqUUef6xhYO87nx9vJNuxg7Yc6J2FdJjXRKbB0iud2ZyzwQ=="
-    },
-    "hyperhtml-wire": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hyperhtml-wire/-/hyperhtml-wire-2.1.0.tgz",
-      "integrity": "sha512-LqFs/MgvxyMVM8O3Fx7QcCDWWkga3JeMA7C1inHM71PIchupSyj2u/zG8Blw+KfJHIFmEsx09KxOrgykGqoopQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tape": "^5.0.1"
   },
   "dependencies": {
-    "hyperhtml": "^2.32.2"
+    "hyperhtml": "^2.32.2",
+    "uhtml": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "tape": "^5.0.1"
   },
   "dependencies": {
-    "hyperhtml": "^2.32.2",
     "uhtml": "^2.0.0"
   }
 }

--- a/test/lib/viewTest.js
+++ b/test/lib/viewTest.js
@@ -11,10 +11,10 @@ test('view.render renders template', (t) => {
   const stringProp = 'hello';
   const booleanProp = false;
   const numberProp = 3;
-  const renderedHtml = '<div id="hello" disabled="false">3</div>';
+  const renderedHtml = '<div id="hello" .disabled="false">3</div>';
   mockFunction(DocumentFragment, () => () => fragment);
   mockFunction(uhtml.html, () => (fixedParts, ...variableParts) => {
-    t.deepEqual(fixedParts, ['<div id=', ' disabled=', '>', '</div>']);
+    t.deepEqual(fixedParts, ['<div id=', ' .disabled=', '>', '</div>']);
     t.deepEqual(variableParts, [stringProp, booleanProp, numberProp]);
     return renderedHtml;
   });
@@ -24,7 +24,7 @@ test('view.render renders template', (t) => {
   });
   view(
     { foo: stringProp, bar: booleanProp, baz: numberProp },
-    (render) => ({ foo, bar, baz }) => render`<div id=${foo} disabled=${bar}>${baz}</div>`,
+    (render) => ({ foo, bar, baz }) => render`<div id=${foo} .disabled=${bar}>${baz}</div>`,
   ).render();
   resetMock(DocumentFragment);
   resetMock(uhtml.html);

--- a/test/lib/viewTest.js
+++ b/test/lib/viewTest.js
@@ -9,12 +9,13 @@ test('view.render renders template', (t) => {
   t.plan(4);
   const fragment = {};
   const stringProp = 'hello';
+  const booleanProp = false;
   const numberProp = 3;
-  const renderedHtml = '<div id="hello">3</div>';
+  const renderedHtml = '<div id="hello" disabled="false">3</div>';
   mockFunction(DocumentFragment, () => () => fragment);
   mockFunction(uhtml.html, () => (fixedParts, ...variableParts) => {
-    t.deepEqual(fixedParts, ['<div id=', '>', '</div>']);
-    t.deepEqual(variableParts, [stringProp, numberProp]);
+    t.deepEqual(fixedParts, ['<div id=', ' disabled=', '>', '</div>']);
+    t.deepEqual(variableParts, [stringProp, booleanProp, numberProp]);
     return renderedHtml;
   });
   mockFunction(uhtml.render, () => (where, what) => {
@@ -22,8 +23,8 @@ test('view.render renders template', (t) => {
     t.equal(what, renderedHtml);
   });
   view(
-    { foo: stringProp, bar: numberProp },
-    (render) => ({ foo, bar }) => render`<div id=${foo}>${bar}</div>`,
+    { foo: stringProp, bar: booleanProp, baz: numberProp },
+    (render) => ({ foo, bar, baz }) => render`<div id=${foo} disabled=${bar}>${baz}</div>`,
   ).render();
   resetMock(DocumentFragment);
   resetMock(uhtml.html);

--- a/test/lib/viewTest.js
+++ b/test/lib/viewTest.js
@@ -1,7 +1,7 @@
 import { test } from 'tape';
 import dependencies from 'dependencies';
 import { mockFunction, mockFunctionSequence, resetMock } from '@/lib/shadow';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const { uhtml, globals: { DocumentFragment } } = dependencies;
 
@@ -79,4 +79,16 @@ test('view.update updates partial or whole props and calls render', (t) => {
   resetMock(DocumentFragment);
   resetMock(uhtml.html);
   resetMock(uhtml.render);
+});
+
+test('toCssText converts object into cssText', (t) => {
+  const styleObject = {
+    fontSize: '10px',
+    color: 'white',
+    fontFamily: 'serif',
+    border: '2px solid black',
+  };
+  const cssText = 'font-size:10px;color:white;font-family:serif;border:2px solid black;';
+  t.equal(toCssText(styleObject), cssText);
+  t.end();
 });

--- a/view/case/numbers.js
+++ b/view/case/numbers.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { CASES_TO_COMPLETE } from '@/constant';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const initialState = {
   number: 1,

--- a/view/case/numbers.js
+++ b/view/case/numbers.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { CASES_TO_COMPLETE } from '@/constant';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const initialState = {
   number: 1,
@@ -9,7 +9,7 @@ const initialState = {
   fontSize: 0,
 };
 
-const leftUpContainerStyle = (fontSize) => ({
+const leftUpContainerStyle = (fontSize) => toCssText({
   position: 'absolute',
   top: '1%',
   left: '1%',
@@ -18,11 +18,11 @@ const leftUpContainerStyle = (fontSize) => ({
   fontFamily: 'serif',
 });
 
-const totalCasesStyle = (fontSize) => ({
+const totalCasesStyle = (fontSize) => toCssText({
   fontSize: `${fontSize * 0.7}px`,
 });
 
-const leftDownConatinerStyle = (fontSize) => ({
+const leftDownConatinerStyle = (fontSize) => toCssText({
   position: 'absolute',
   bottom: '1%',
   left: '1%',

--- a/view/case/tapes.js
+++ b/view/case/tapes.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import tapeSubject from '@/subject/tape';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 
 const orderView = tapeGen();
@@ -12,15 +12,15 @@ const initialState = {
   fontSize: 10,
 };
 
-const containerStyle = {
+const containerStyle = toCssText({
   position: 'absolute',
   top: '3%',
   width: '100%',
   fontFamily: 'serif',
   color: 'white',
-};
+});
 
-const tableStyle = (fontSize) => ({
+const tableStyle = (fontSize) => toCssText({
   margin: '0 auto',
   fontSize: `${fontSize}px`,
   lineHeight: `${fontSize}px`,

--- a/view/case/tapes.js
+++ b/view/case/tapes.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import tapeSubject from '@/subject/tape';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 
 const orderView = tapeGen();

--- a/view/control/control.js
+++ b/view/control/control.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { enqueue, signals } from '@/subject/inputSignal';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const initialState = {
   running: false,

--- a/view/control/control.js
+++ b/view/control/control.js
@@ -38,11 +38,11 @@ const controlView = view(initialState, (render) => ({
   <button
     style=${buttonStyle(fontSize, height)}
     onclick=${running ? onClickHaltButton : onClickResetButton}
-    disabled=${disabled}>${running ? 'HALT' : 'RESET'}</button>
+    .disabled=${disabled}>${running ? 'HALT' : 'RESET'}</button>
   <button
     style=${buttonStyle(fontSize, height)}
     onclick=${onClickPassButton}
-    disabled=${disabled || running}>PASS</button>
+    .disabled=${disabled || running}>PASS</button>
 </div>`);
 
 windowSize.subscribe(({ width: windowWidth, height: windowHeight }) => {

--- a/view/control/control.js
+++ b/view/control/control.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { enqueue, signals } from '@/subject/inputSignal';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const initialState = {
   running: false,
@@ -9,7 +9,7 @@ const initialState = {
   height: 0,
 };
 
-const containerStyle = {
+const containerStyle = toCssText({
   display: 'table-cell',
   position: 'absolute',
   top: '19%',
@@ -18,9 +18,9 @@ const containerStyle = {
   textAlign: 'center',
   verticalAlign: 'middle',
   fontFamily: 'Courier New',
-};
+});
 
-const buttonStyle = (fontSize, height) => ({
+const buttonStyle = (fontSize, height) => toCssText({
   margin: `${(height - fontSize) / 2}px 0.5em`,
   width: `${fontSize * 5}px`,
   height: `${fontSize}px`,

--- a/view/curtain/curtain.js
+++ b/view/curtain/curtain.js
@@ -1,5 +1,5 @@
 import { signals, enqueue } from '@/subject/inputSignal';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const curtainStyle = (opacity) => ({
   display: opacity === 0 ? 'none' : 'block',

--- a/view/curtain/curtain.js
+++ b/view/curtain/curtain.js
@@ -1,7 +1,7 @@
 import { signals, enqueue } from '@/subject/inputSignal';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
-const curtainStyle = (opacity) => ({
+const curtainStyle = (opacity) => toCssText({
   display: opacity === 0 ? 'none' : 'block',
   position: 'absolute',
   top: 0,

--- a/view/generator/tapeGen.js
+++ b/view/generator/tapeGen.js
@@ -1,6 +1,6 @@
 import dependencies from 'dependencies';
 import { randomTape } from '@/subject/tape';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const { wire } = dependencies.hyperhtml;
 
@@ -12,16 +12,16 @@ export default () => {
   };
   const cellDivs = initialState.tape.map(() => wire({}));
   return view(initialState, (render) => ({ tape, style, cellWidth }) => {
-    const tapeStyle = {
+    const tapeStyle = toCssText({
       width: `${cellWidth * 10}px`,
       height: `${cellWidth}px`,
       ...style,
-    };
+    });
     return render`<div style=${tapeStyle}>${
       tape.map((bit, index) => {
         const background = 255 * bit;
         const foreground = 255 - background;
-        const cellStyle = {
+        const cellStyle = toCssText({
           display: 'inline-block',
           width: `${cellWidth}px`,
           height: `${cellWidth}px`,
@@ -30,7 +30,7 @@ export default () => {
           textAlign: 'center',
           backgroundColor: `rgb(${background},${background},${background})`,
           color: `rgb(${foreground},${foreground},${foreground})`,
-        };
+        });
         return cellDivs[index]`<div style=${cellStyle}>${bit < 0.5 ? 0 : 1}</div>`;
       })
     }</div>`;

--- a/view/generator/tapeGen.js
+++ b/view/generator/tapeGen.js
@@ -1,8 +1,24 @@
-import dependencies from 'dependencies';
 import { randomTape } from '@/subject/tape';
 import { view, toCssText } from '@/lib/view';
 
-const { wire } = dependencies.hyperhtml;
+const cellViewGen = (initialBit) => view(
+  { bit: initialBit, cellWidth: 0 },
+  (render) => ({ bit, cellWidth }) => {
+    const background = 255 * bit;
+    const foreground = 255 - background;
+    const cellStyle = toCssText({
+      display: 'inline-block',
+      width: `${cellWidth}px`,
+      height: `${cellWidth}px`,
+      lineHeight: `${cellWidth}px`,
+      fontSize: `${cellWidth}px`,
+      textAlign: 'center',
+      backgroundColor: `rgb(${background},${background},${background})`,
+      color: `rgb(${foreground},${foreground},${foreground})`,
+    });
+    return render`<div style=${cellStyle}>${bit < 0.5 ? 0 : 1}</div>`;
+  },
+);
 
 export default () => {
   const initialState = {
@@ -10,29 +26,14 @@ export default () => {
     style: {},
     cellWidth: 0,
   };
-  const cellDivs = initialState.tape.map(() => wire({}));
+  const cellViews = initialState.tape.map((bit) => cellViewGen(bit));
   return view(initialState, (render) => ({ tape, style, cellWidth }) => {
     const tapeStyle = toCssText({
       width: `${cellWidth * 10}px`,
       height: `${cellWidth}px`,
       ...style,
     });
-    return render`<div style=${tapeStyle}>${
-      tape.map((bit, index) => {
-        const background = 255 * bit;
-        const foreground = 255 - background;
-        const cellStyle = toCssText({
-          display: 'inline-block',
-          width: `${cellWidth}px`,
-          height: `${cellWidth}px`,
-          lineHeight: `${cellWidth}px`,
-          fontSize: `${cellWidth}px`,
-          textAlign: 'center',
-          backgroundColor: `rgb(${background},${background},${background})`,
-          color: `rgb(${foreground},${foreground},${foreground})`,
-        });
-        return cellDivs[index]`<div style=${cellStyle}>${bit < 0.5 ? 0 : 1}</div>`;
-      })
-    }</div>`;
+    cellViews.forEach((v, index) => v.update(() => ({ cellWidth, bit: tape[index] })));
+    return render`<div style=${tapeStyle}>${cellViews.map((v) => v.render())}</div>`;
   });
 };

--- a/view/generator/tapeGen.js
+++ b/view/generator/tapeGen.js
@@ -1,6 +1,6 @@
 import dependencies from 'dependencies';
 import { randomTape } from '@/subject/tape';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const { wire } = dependencies.hyperhtml;
 

--- a/view/machine/head.js
+++ b/view/machine/head.js
@@ -1,5 +1,5 @@
 import windowSize from '@/subject/windowSize';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const initialState = {
   state: 0,
@@ -12,12 +12,12 @@ const stateToString = (state) => (
 
 const headView = view(initialState, (render) => ({ state, cellWidth }) => {
   const w16 = cellWidth / 16;
-  const containerStyle = {
+  const containerStyle = toCssText({
     position: 'absolute',
     top: '30%',
     left: '50%',
     transform: `translate(-${cellWidth / 2 + w16}px, 0)`,
-  };
+  });
   const commonStyle = {
     position: 'absolute',
     height: `${cellWidth}px`,
@@ -28,19 +28,19 @@ const headView = view(initialState, (render) => ({ state, cellWidth }) => {
     width: `${w16 * 2}px`,
     borderRadius: `${w16}px ${w16}px 0 0`,
   };
-  const headStyle = {
+  const headStyle = toCssText({
     ...commonStyle,
     top: `${cellWidth}px`,
     width: `${cellWidth + w16 * 2}px`,
     borderRadius: `0 0 ${w16}px ${w16}px`,
-    fontSize: cellWidth * 0.8,
+    fontSize: `${cellWidth * 0.8}px`,
     lineHeight: `${cellWidth}px`,
     textAlign: 'center',
     color: 'white',
-  };
+  });
   return render`<div style=${containerStyle}>
-    <div style=${armStyle} />
-    <div style=${{ ...armStyle, left: cellWidth }} />
+    <div style=${toCssText(armStyle)} />
+    <div style=${toCssText({ ...armStyle, left: `${cellWidth}px` })} />
     <div style=${headStyle}>${stateToString(state)}</div>
   </div>`;
 });

--- a/view/machine/head.js
+++ b/view/machine/head.js
@@ -1,5 +1,5 @@
 import windowSize from '@/subject/windowSize';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const initialState = {
   state: 0,

--- a/view/machine/tape.js
+++ b/view/machine/tape.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import tapeSubject from '@/subject/tape';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 
 const tapeView = tapeGen();
@@ -8,12 +8,12 @@ const tapeView = tapeGen();
 const containerView = view({ position: 0 }, (render) => ({
   position, cellWidth,
 }) => {
-  const containerStyle = {
+  const containerStyle = toCssText({
     position: 'absolute',
     top: '30%',
     left: '50%',
     transform: `translate(${cellWidth * (-0.5 - position)}px, 0)`,
-  };
+  });
   tapeView.update(() => ({ cellWidth }));
   return render`<div style=${containerStyle}>${tapeView.render()}</div>`;
 });

--- a/view/machine/tape.js
+++ b/view/machine/tape.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import tapeSubject from '@/subject/tape';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 
 const tapeView = tapeGen();

--- a/view/program/command.js
+++ b/view/program/command.js
@@ -34,10 +34,10 @@ export default (index) => view(initialState(index >> 1, index & 0), (render) => 
   state0, char0, direction, char1, state1, disabled,
 }) => render`<div style=${containerStyle}>${
   `<${state0},${char0},`
-}<button onclick=${updateDirection(index, direction)} disabled=${disabled}>${directionToString(direction)}</button>${
+}<button onclick=${updateDirection(index, direction)} .disabled=${disabled}>${directionToString(direction)}</button>${
   ','
-}<button onclick=${updateChar1(index, char1)} disabled=${disabled}>${char1}</button>${
+}<button onclick=${updateChar1(index, char1)} .disabled=${disabled}>${char1}</button>${
   ','
-}<button onclick=${updateState1(index, state1)} disabled=${disabled}>${stateStrings[state1]}</button>${
+}<button onclick=${updateState1(index, state1)} .disabled=${disabled}>${stateStrings[state1]}</button>${
   '>'
 }</div>`);

--- a/view/program/command.js
+++ b/view/program/command.js
@@ -1,4 +1,4 @@
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import { updateCommand } from '@/subject/program';
 
 const initialState = (state0, char0) => ({
@@ -10,12 +10,12 @@ const initialState = (state0, char0) => ({
   disabled: false,
 });
 
-const containerStyle = {
+const containerStyle = toCssText({
   display: 'inline-block',
   margin: '1% 1%',
   textAlign: 'center',
   whiteSpace: 'nowrap',
-};
+});
 
 const directionToString = (direction) => (direction < 0 ? 'L' : 'R');
 const stateStrings = ['0', '1', '2', '3', '4', 'A'];

--- a/view/program/command.js
+++ b/view/program/command.js
@@ -1,4 +1,4 @@
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import { updateCommand } from '@/subject/program';
 
 const initialState = (state0, char0) => ({

--- a/view/program/window.js
+++ b/view/program/window.js
@@ -1,7 +1,7 @@
 import windowSize from '@/subject/windowSize';
 import { programSubject } from '@/subject/program';
 import { enqueue, signals } from '@/subject/inputSignal';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import commandView from './command';
 
 const initialState = {
@@ -12,12 +12,12 @@ const initialState = {
 
 const commandViews = [...Array(10)].map((_, index) => commandView(index));
 
-const containerStyle = (fontSize, style) => ({
+const containerStyle = (fontSize, style) => toCssText({
   position: 'absolute',
   top: '29%',
   left: '50%',
   transform: 'translate(-50%, 0)',
-  width: fontSize * 20,
+  width: `${fontSize * 20}px`,
   padding: '5px 0 10px 0',
   textAlign: 'center',
   fontSize: `${fontSize}px`,
@@ -29,20 +29,20 @@ const containerStyle = (fontSize, style) => ({
   ...style,
 });
 
-const titleStyle = {
+const titleStyle = toCssText({
   marginBottom: '10px',
-};
+});
 
 const runButonStyle = (fontSize) => {
   const height = `${fontSize * 1.3}px`;
-  return {
+  return toCssText({
     height,
     marginTop: '0.1em',
     padding: '0 1em',
     fontSize: height,
     lineHeight: height,
     borderRadius: `${fontSize * 0.15}px`,
-  };
+  });
 };
 
 // Taking onClickRunButton as argument to go around `no-use-before-defined`

--- a/view/program/window.js
+++ b/view/program/window.js
@@ -1,7 +1,7 @@
 import windowSize from '@/subject/windowSize';
 import { programSubject } from '@/subject/program';
 import { enqueue, signals } from '@/subject/inputSignal';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import commandView from './command';
 
 const initialState = {

--- a/view/program/window.js
+++ b/view/program/window.js
@@ -55,7 +55,7 @@ const windowView = view(initialState, (({ onClickRunButton }) => (render) => ({
     <div>${commandViews.map((v) => v.render())}</div>
     <button
       style=${runButonStyle(fontSize)}
-      disabled=${disabled}
+      .disabled=${disabled}
       onclick=${onClickRunButton}>RUN</button>
   </div>`;
 })({

--- a/view/result/caseResult.js
+++ b/view/result/caseResult.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { TIME_LIMIT } from '@/constant';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import { showTime, showScore } from '../case/numbers';
 
 export const types = {

--- a/view/result/caseResult.js
+++ b/view/result/caseResult.js
@@ -1,6 +1,6 @@
 import windowSize from '@/subject/windowSize';
 import { TIME_LIMIT } from '@/constant';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import { showTime, showScore } from '../case/numbers';
 
 export const types = {
@@ -19,7 +19,7 @@ const initialState = {
   fontSize: 0,
 };
 
-const containerStyle = (opacity) => ({
+const containerStyle = (opacity) => toCssText({
   display: opacity === 0 ? 'none' : 'block',
   position: 'absolute',
   top: '10%',
@@ -36,7 +36,7 @@ const titleColor = new Map([
   [types.timeup, '#ccf'],
 ]);
 
-const titleStyle = (type, fontSize) => ({
+const titleStyle = (type, fontSize) => toCssText({
   color: titleColor.get(type),
   fontSize: `${fontSize}px`,
 });
@@ -47,14 +47,16 @@ const titleText = new Map([
   [types.timeup, "Time's up."],
 ]);
 
-const scoreBoardStyle = (fontSize) => ({
+const scoreBoardStyle = (fontSize) => toCssText({
   display: 'inline-block',
   margin: `${fontSize}px 0`,
   fontSize: `${fontSize}px`,
   color: 'white',
 });
 
-const bonusStyle = (fontSize) => ({ fontSize });
+const bonusStyle = (fontSize) => toCssText({
+  fontSize: `${fontSize}px`,
+});
 
 export const bonus = (commandsSaved, accepted, steps, timeLeft) => (
   (commandsSaved + (accepted ? 1 : 0)) * 100 * steps * 0.1 * (timeLeft / TIME_LIMIT) * 3 | 0

--- a/view/result/totalResult.js
+++ b/view/result/totalResult.js
@@ -1,5 +1,5 @@
 import windowSize from '@/subject/windowSize';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 import { showScore } from '@/view/case/numbers';
 
@@ -12,7 +12,7 @@ const initialState = {
   fontSize: 0,
 };
 
-const containerStyle = (opacity, fontSize) => ({
+const containerStyle = (opacity, fontSize) => toCssText({
   display: opacity === 0 ? 'none' : 'block',
   position: 'absolute',
   top: '10%',
@@ -25,7 +25,7 @@ const containerStyle = (opacity, fontSize) => ({
   filter: 'drop-shadow(0 0 0.3rem black)',
 });
 
-const titleStyle = (finished, fontSize) => ({
+const titleStyle = (finished, fontSize) => toCssText({
   marginBottom: `${fontSize}px`,
   fontSize: `${fontSize}px`,
   color: finished ? '#fc9' : '#c99',
@@ -37,7 +37,7 @@ const tapeView = tapeGen();
 const tapeStyle = { display: 'inline-block' };
 [orderView, tapeView].forEach((v) => v.update(() => ({ style: tapeStyle })));
 
-const scoreStyle = (fontSize) => ({
+const scoreStyle = (fontSize) => toCssText({
   fontSize: `${fontSize}px`,
   marginTop: `${fontSize}px`,
 });
@@ -49,7 +49,7 @@ const totalResult = view(initialState, (render) => ({
   tapeView.update(() => ({ tape, cellWidth: fontSize }));
   return render`<div style=${containerStyle(opacity, fontSize)}>
     <div style=${titleStyle(finished, fontSize * 1.3)}>${finished ? 'Finished!' : 'Game Over'}</div>
-    <div style=${{ display: finished ? 'none' : 'block' }}>${finished ? '' : `at No.${caseNumber}`}</div>
+    <div style=${`display:${finished ? 'none' : 'block'}`}>${finished ? '' : `at No.${caseNumber}`}</div>
     ${finished ? '' : orderView.render()}<br>${finished ? '' : tapeView.render()}<br>
     <div style=${scoreStyle(fontSize)}>Total score: ${showScore(score)}</div>
   </div>`;

--- a/view/result/totalResult.js
+++ b/view/result/totalResult.js
@@ -1,5 +1,5 @@
 import windowSize from '@/subject/windowSize';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 import tapeGen from '@/view/generator/tapeGen';
 import { showScore } from '@/view/case/numbers';
 

--- a/view/title/title.js
+++ b/view/title/title.js
@@ -1,12 +1,12 @@
 import windowSize from '@/subject/windowSize';
-import { view } from '@/lib/view';
+import { view, toCssText } from '@/lib/view';
 
 const initialState = {
   opacity: 0,
   fontSize: 0,
 };
 
-const containerStyle = (opacity) => ({
+const containerStyle = (opacity) => toCssText({
   display: opacity === 0 ? 'none' : 'block',
   position: 'absolute',
   width: '100%',
@@ -16,7 +16,7 @@ const containerStyle = (opacity) => ({
   opacity,
 });
 
-const titleStyle = (fontSize) => ({
+const titleStyle = (fontSize) => toCssText({
   fontSize: `${fontSize}px`,
   color: 'orange',
 });

--- a/view/title/title.js
+++ b/view/title/title.js
@@ -1,5 +1,5 @@
 import windowSize from '@/subject/windowSize';
-import view from '@/lib/view';
+import { view } from '@/lib/view';
 
 const initialState = {
   opacity: 0,


### PR DESCRIPTION
- `view` use `DocumentFragment` to do the same thing with `hyperhtml.wire({})`
  - Mocking constructor is annoying, so may deprecate/remove `mockConstructor`
- Defined `toCssText` in view.js because `uhtml` doesn't accept object as `style`
  - This implementation is naive, but goes well with current TMP codes
- `disabled` => `.disabled`
- Separate `cellViewGen` from `tapeGen`, making it depends on only `view`
- Reduced bundle size from 32KB to 21KB
